### PR TITLE
Improve lease summary prompt and fix suggested actions rendering

### DIFF
--- a/app/api/ask-ai/upload/route.ts
+++ b/app/api/ask-ai/upload/route.ts
@@ -154,6 +154,7 @@ export async function POST(req: Request) {
       const ab = await file.arrayBuffer()
       const text = await extractText(new Uint8Array(ab), file.name)
       const out = await summarizeAndSuggest(text.text, file.name)
+      console.debug('summarizeAndSuggest output:', out)
       
       // Determine extraction method for user feedback
       let extractionMethod = 'standard';
@@ -175,7 +176,7 @@ export async function POST(req: Request) {
         filename: file.name,
         buildingId,
         summary: out.summary,
-        suggestedActions: out.suggestions ?? [],
+        suggestedActions: Array.isArray(out.suggestions) ? out.suggestions : [],
         extractionMethod,
         extractionNote,
         textLength: text.text.length,
@@ -197,16 +198,17 @@ export async function POST(req: Request) {
       if (error || !data) return NextResponse.json({ success: false, error: error?.message || 'download failed' }, { status: 500 })
 
       const ab = await data.arrayBuffer()
-      const text = await extractText(new Uint8Array(ab), path)
-      const out = await summarizeAndSuggest(text, path)
-      return NextResponse.json({
-        success: true,
-        filename: path.split('/').pop(),
-        buildingId,
-        summary: out.summary,
-        suggestedActions: out.suggestedActions ?? [],
-      })
-    }
+        const text = await extractText(new Uint8Array(ab), path)
+        const out = await summarizeAndSuggest(text, path)
+        console.debug('summarizeAndSuggest output:', out)
+        return NextResponse.json({
+          success: true,
+          filename: path.split('/').pop(),
+          buildingId,
+          summary: out.summary,
+          suggestedActions: Array.isArray(out.suggestedActions) ? out.suggestedActions : [],
+        })
+      }
 
     return NextResponse.json({ success: false, error: `Unsupported content-type: ${ct}` }, { status: 415 })
   } catch (e: any) {

--- a/app/api/extract/route.ts
+++ b/app/api/extract/route.ts
@@ -126,18 +126,22 @@ export async function POST(request: NextRequest) {
         // Generate AI summary using OpenAI
         if (process.env.OPENAI_API_KEY) {
           try {
-            const prompt = `Based on the following lease clauses extracted from a property lease document, provide a clear, concise summary in plain English. Focus on the key terms and conditions that would be most important for property managers and leaseholders to understand.
+            const prompt = `You are analysing a UK residential lease. Using the extracted clauses below, produce a structured summary with key metadata. If an item is missing, state "Not specified".
 
 Lease Clauses:
 ${Object.entries(clauses).map(([term, clause]) => `${term}: ${clause.text || 'Not found'}`).join('\n')}
 
-Please provide:
-1. A brief overview of the lease type and key terms
-2. Important clauses that were found and their significance
-3. Any notable conditions or restrictions
-4. A confidence assessment of the extraction quality
+Include in your summary:
+1. Leaseholder (tenant) name
+2. Unit or property address/identifier
+3. Lease start date and term or expiry date
+4. Ground rent and service charge obligations
+5. Repair and maintenance responsibilities
+6. Restrictions (e.g. pets, alterations, subletting)
+7. Any other notable conditions or covenants
+8. A confidence assessment of the extraction quality
 
-Keep the summary professional but accessible, suitable for property management professionals.`;
+Conclude with a one-sentence overall summary. Use professional, concise language suitable for property managers.`;
 
             const completion = await openai.chat.completions.create({
               model: 'gpt-4o',

--- a/components/AskBlocIQ.tsx
+++ b/components/AskBlocIQ.tsx
@@ -747,12 +747,14 @@ export default function AskBlocIQ({
                             </p>
                             {analysis.suggestedActions && analysis.suggestedActions.length > 0 && (
                               <div className="flex flex-wrap gap-1">
-                                {analysis.suggestedActions.map((action: string, actionIndex: number) => (
-                                  <span 
+                                {analysis.suggestedActions.map((action: any, actionIndex: number) => (
+                                  <span
                                     key={actionIndex}
                                     className="inline-block px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded-full"
                                   >
-                                    {action}
+                                    {typeof action === 'string'
+                                      ? action
+                                      : action?.label || action?.key || JSON.stringify(action)}
                                   </span>
                                 ))}
                               </div>

--- a/components/inbox_v2/MessagePreview.tsx
+++ b/components/inbox_v2/MessagePreview.tsx
@@ -409,8 +409,12 @@ export default function MessagePreview({ selectedMessage, onReply, onReplyAll, o
                 <div className="mt-2">
                   <strong>Suggested Actions:</strong>
                   <ul className="list-disc list-inside mt-1 ml-2">
-                    {triageResult.suggestedActions.map((action: string, index: number) => (
-                      <li key={index}>{action}</li>
+                    {triageResult.suggestedActions.map((action: any, index: number) => (
+                      <li key={index}>
+                        {typeof action === 'string'
+                          ? action
+                          : action?.label || action?.key || JSON.stringify(action)}
+                      </li>
                     ))}
                   </ul>
                 </div>

--- a/lib/ask/summarize-and-suggest.ts
+++ b/lib/ask/summarize-and-suggest.ts
@@ -29,6 +29,7 @@ SUGGESTIONS:
   });
 
   const content = resp.choices?.[0]?.message?.content || '';
+  console.debug('Raw AI summarize output:', content);
   const [ , summaryPart = '', suggestionsPart = '[]' ] =
     content.match(/SUMMARY:\s*([\s\S]*?)\nSUGGESTIONS:\s*([\s\S]*)$/i) || [];
 


### PR DESCRIPTION
## Summary
- refine lease document prompt to extract concrete metadata like leaseholder, unit and key dates
- add debug logging and suggestion fallback for document analysis API
- render suggested actions using their labels to avoid `[object Object]`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: react/no-unescaped-entities and @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68af1cea2e8c833081dd9be86f5e9c09